### PR TITLE
Updated maximum value to 1800

### DIFF
--- a/tasks/powershell_herd_resolver.ps1
+++ b/tasks/powershell_herd_resolver.ps1
@@ -2,6 +2,6 @@
 
 # Puppet Task Name:powershell_herd_resolver 
 #
-sleep -s  $(Get-Random -minimum 1 -maximum $(puppet agent --configprint runinterval))
+sleep -s  $(Get-Random -minimum 1 -maximum 1800 $(puppet agent --configprint runinterval))
 puppet resource service puppet ensure=stopped
 puppet resource service puppet ensure=running


### PR DESCRIPTION
Max value is now set to 30 minutes. If this isn't set, values higher than the windows maximum sleep time (24 days) can be set which can cause errors.