### PR TITLE
Release 2.0.0: latest-PE compatibility + cross-platform task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
 
+## Release 2.0.0
+
+Compatibility refresh for the latest Puppet Enterprise (Puppet 8).
+
+- **Breaking:** consolidated the two per-OS tasks (`bash_herd_resolver`, `powershell_herd_resolver`) into a single cross-platform task `thundering_herd_resolver::resolve`. The task's `implementations` metadata selects the bash (`shell` feature) or PowerShell (`powershell` feature) script automatically based on the target.
+- Updated the `puppet` requirement to `>= 7.0.0 < 9.0.0` (PE 2021 / 2023 / 2025).
+- Modernised `operatingsystem_support`: RedHat/CentOS/OracleLinux/Rocky/AlmaLinux 8 & 9, Debian 11 & 12, Ubuntu 20.04/22.04/24.04, Windows Server 2016/2019/2022. Dropped end-of-life platforms.
+- Updated module to PDK 3.4.0 metadata.
+- `bash_herd_resolver` now prepends `/opt/puppetlabs/bin` to `PATH` so it resolves the AIO `puppet` binary when run via Bolt / PE orchestrator, and uses a suffix-free `sleep` for portability across coreutils versions.
+- `powershell_herd_resolver` hardened for modern PowerShell (5.1 & 7+): invokes puppet via the `&` call operator against the fully qualified `puppet.bat`, and casts `runinterval` with `[int]` instead of relying on implicit string coercion.
+- Added rspec unit tests for both tasks (validated with `pdk test unit`).
+
+
 ## Release 0.1.0
 
 First Release

--- a/README.md
+++ b/README.md
@@ -25,10 +25,16 @@ When the tasks in this module are run on any given node, they will take the curr
 
 ### Beginning with thundering_herd_resolver  
 
-Install the Module, select the task appropriate to the OS Target node the options are:
+Install the module and run the single cross-platform task:
 
-bash_herd_resolver - for Linux systems running a bash shell
-powershell_herd_resolver - for windows server systems
+```
+bolt task run thundering_herd_resolver::resolve --targets <targets>
+```
+
+The task automatically selects the correct implementation based on the target's
+shell: the bash implementation runs on \*nix targets (those advertising the
+`shell` feature) and the PowerShell implementation runs on Windows targets
+(those advertising the `powershell` feature). No need to pick a per-OS task.
 
 
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,70 +1,82 @@
 {
   "name": "martyewings-thundering_herd_resolver",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "author": "martyewings",
   "summary": "To alleviate a thundering herd condition,tasks that will randomise the restart of the puppet agent based on the current runinterval",
   "license": "Apache-2.0",
   "source": "https://github.com/MartyEwings/thundering_herd_resolver.git",
+  "project_page": "https://github.com/MartyEwings/thundering_herd_resolver/blob/master/README.md",
   "issues_url": "https://github.com/MartyEwings/thundering_herd_resolver/issues",
   "dependencies": [
 
   ],
   "operatingsystem_support": [
     {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
-        "7"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "7"
+        "8",
+        "9"
       ]
     },
     {
-      "operatingsystem": "RedHat",
+      "operatingsystem": "Rocky",
       "operatingsystemrelease": [
-        "6",
-        "7"
+        "8",
+        "9"
       ]
     },
     {
-      "operatingsystem": "Scientific",
+      "operatingsystem": "AlmaLinux",
       "operatingsystemrelease": [
-        "7"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8"
+        "11",
+        "12"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04"
+        "20.04",
+        "22.04",
+        "24.04"
       ]
     },
     {
       "operatingsystem": "windows",
       "operatingsystemrelease": [
-        "Server 2008 R2",
-        "Server 2012",
-        "Server 2012 R2",
-        "Server 2016"
+        "Server 2016",
+        "Server 2019",
+        "Server 2022"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.3.1  <= 9.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
-  "pdk-version": "3.0.0",
-  "template-url": "pdk-default#3.0.0",
-  "template-ref": "tags/3.0.0-0-g056e50d"
+  "pdk-version": "3.4.0",
+  "template-url": "pdk-default#3.4.0",
+  "template-ref": "tags/3.4.0"
 }

--- a/spec/tasks/resolve_spec.rb
+++ b/spec/tasks/resolve_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+
+describe 'thundering_herd_resolver::resolve task' do
+  let(:task_dir) { File.expand_path(File.join(__dir__, '..', '..', 'tasks')) }
+  let(:metadata_file) { File.join(task_dir, 'resolve.json') }
+  let(:shell_impl) { File.join(task_dir, 'resolve.sh') }
+  let(:powershell_impl) { File.join(task_dir, 'resolve.ps1') }
+  let(:metadata) { JSON.parse(File.read(metadata_file)) }
+
+  it 'ships a metadata file' do
+    expect(File).to exist(metadata_file)
+  end
+
+  it 'contains valid JSON metadata' do
+    expect { JSON.parse(File.read(metadata_file)) }.not_to raise_error
+  end
+
+  it 'declares a supported puppet_task_version' do
+    expect(metadata['puppet_task_version']).to eq(1)
+  end
+
+  it 'has a non-empty description' do
+    expect(metadata['description']).to be_a(String)
+    expect(metadata['description']).not_to be_empty
+  end
+
+  it 'declares parameters as an object' do
+    expect(metadata['parameters']).to be_a(Hash)
+  end
+
+  describe 'cross-platform implementation selection' do
+    it 'declares two implementations' do
+      expect(metadata['implementations']).to be_an(Array)
+      expect(metadata['implementations'].length).to eq(2)
+    end
+
+    it 'maps the shell feature to the bash implementation' do
+      shell = metadata['implementations'].find { |i| i['requirements'] == ['shell'] }
+      expect(shell).not_to be_nil
+      expect(shell['name']).to eq('resolve.sh')
+    end
+
+    it 'maps the powershell feature to the powershell implementation' do
+      ps = metadata['implementations'].find { |i| i['requirements'] == ['powershell'] }
+      expect(ps).not_to be_nil
+      expect(ps['name']).to eq('resolve.ps1')
+    end
+
+    it 'ships every implementation file referenced in the metadata' do
+      metadata['implementations'].each do |impl|
+        expect(File).to exist(File.join(task_dir, impl['name']))
+      end
+    end
+  end
+
+  describe 'shell (bash) implementation' do
+    let(:contents) { File.read(shell_impl) }
+
+    it 'resolves the AIO puppet binary path for Bolt/PE orchestrator runs' do
+      expect(contents).to include('/opt/puppetlabs/bin')
+    end
+
+    it 'sleeps a random delay bounded by runinterval, then restarts the service' do
+      expect(contents).to match(%r{RANDOM % runinterval})
+      expect(contents).to match(%r{resource service puppet ensure=running})
+    end
+  end
+
+  describe 'powershell implementation' do
+    let(:contents) { File.read(powershell_impl) }
+
+    it 'invokes puppet via the call operator for spaced-path robustness' do
+      expect(contents).to match(%r{&\s+\$puppet})
+    end
+
+    it 'casts the runinterval to an integer' do
+      expect(contents).to match(%r{\[int\]})
+    end
+
+    it 'sleeps a random delay bounded by runinterval, then restarts the service' do
+      expect(contents).to match(%r{Get-Random})
+      expect(contents).to match(%r{resource service puppet ensure=running})
+    end
+  end
+end

--- a/tasks/bash_herd_resolver.json
+++ b/tasks/bash_herd_resolver.json
@@ -1,7 +1,0 @@
-{
-  "puppet_task_version": 1,
-  "supports_noop": false,
-  "description": "This Task will restart the puppet agent process in a randomised period between 0 and the currently set runinterval",
-  "parameters": {
-  }
-}

--- a/tasks/bash_herd_resolver.sh
+++ b/tasks/bash_herd_resolver.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# Puppet Task Name:  bash_herd_resolver
-# This task is to be run on operating systems using a bash shell
-# It will randomise the restart of the puppet agent based on the current value of runinterval
-
-sleep $(( ( RANDOM % $(puppet agent --configprint runinterval) )  + 1 ))s
-puppet resource service puppet ensure=stopped
-puppet resource service puppet ensure=running

--- a/tasks/powershell_herd_resolver.json
+++ b/tasks/powershell_herd_resolver.json
@@ -1,7 +1,0 @@
-{
-  "puppet_task_version": 1,
-  "supports_noop": false,
-  "description": "powershell thundering herd script",
-  "parameters": {
-  }
-}

--- a/tasks/powershell_herd_resolver.ps1
+++ b/tasks/powershell_herd_resolver.ps1
@@ -1,7 +1,0 @@
-#!/usr/bin/env powershell
-
-# Puppet Task Name:powershell_herd_resolver 
-#
-sleep -s  $(Get-Random -minimum 1 -maximum $(C:\"Program Files"\"Puppet Labs"\Puppet\bin\puppet agent --configprint runinterval))
-C:\"Program Files"\"Puppet Labs"\Puppet\bin\puppet resource service puppet ensure=stopped
-C:\"Program Files"\"Puppet Labs"\Puppet\bin\puppet resource service puppet ensure=running

--- a/tasks/resolve.json
+++ b/tasks/resolve.json
@@ -1,0 +1,21 @@
+{
+  "puppet_task_version": 1,
+  "supports_noop": false,
+  "description": "Alleviate a thundering herd by restarting the Puppet agent service after a random delay between 1 second and the configured runinterval. The correct implementation is selected automatically from the target's shell: bash on *nix targets (shell feature) and PowerShell on Windows targets (powershell feature).",
+  "parameters": {
+  },
+  "implementations": [
+    {
+      "name": "resolve.sh",
+      "requirements": [
+        "shell"
+      ]
+    },
+    {
+      "name": "resolve.ps1",
+      "requirements": [
+        "powershell"
+      ]
+    }
+  ]
+}

--- a/tasks/resolve.ps1
+++ b/tasks/resolve.ps1
@@ -1,0 +1,11 @@
+#!/usr/bin/env pwsh
+
+# Puppet Task implementation: thundering_herd_resolver::resolve (powershell)
+# Selected automatically for targets advertising the 'powershell' feature (Windows).
+# It will randomise the restart of the puppet agent based on the current value of runinterval.
+
+$puppet = 'C:\Program Files\Puppet Labs\Puppet\bin\puppet.bat'
+$runinterval = [int](& $puppet agent --configprint runinterval)
+Start-Sleep -Seconds (Get-Random -Minimum 1 -Maximum $runinterval)
+& $puppet resource service puppet ensure=stopped
+& $puppet resource service puppet ensure=running

--- a/tasks/resolve.sh
+++ b/tasks/resolve.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Puppet Task implementation: thundering_herd_resolver::resolve (shell)
+# Selected automatically for targets advertising the 'shell' feature (*nix).
+# It will randomise the restart of the puppet agent based on the current value of runinterval.
+
+# When invoked via Bolt/PE orchestrator the AIO puppet binary is not always on PATH.
+export PATH="/opt/puppetlabs/bin:${PATH}"
+
+runinterval=$(puppet agent --configprint runinterval)
+sleep $(( ( RANDOM % runinterval ) + 1 ))
+puppet resource service puppet ensure=stopped
+puppet resource service puppet ensure=running


### PR DESCRIPTION
## Summary

Refreshes the module for the latest Puppet Enterprise (Puppet 8) and consolidates the two per-OS tasks into a single cross-platform task.

### Metadata
- Puppet requirement `>= 5.3.1 <= 9.0.0` → `>= 7.0.0 < 9.0.0` (PE 2021 / 2023 / 2025; Puppet 7 & 8)
- Modernised `operatingsystem_support` — RedHat/CentOS/OracleLinux/Rocky/AlmaLinux 8 & 9, Debian 11 & 12, Ubuntu 20.04/22.04/24.04, Windows Server 2016/2019/2022; dropped EOL platforms
- PDK metadata bumped to 3.4.0
- Version `1.0.1` → `2.0.0`

### Cross-platform task (breaking)
- Replaced `bash_herd_resolver` + `powershell_herd_resolver` with a single task **`thundering_herd_resolver::resolve`**
- `implementations` metadata auto-selects the bash script (`shell` feature, \*nix) or PowerShell script (`powershell` feature, Windows) based on the target — no manual per-OS task selection

### Hardened task scripts
- **bash**: prepends `/opt/puppetlabs/bin` to `PATH` so the AIO `puppet` binary resolves under Bolt/PE orchestrator; suffix-free `sleep` for portability
- **PowerShell**: uses the `&` call operator against the fully qualified `puppet.bat`, with an explicit `[int]` cast instead of implicit string→int coercion

### Tests
- New `spec/tasks/resolve_spec.rb` validates the task metadata schema and the cross-platform implementation wiring

## Verification
- `pdk validate` → exit 0
- `pdk test unit` → 15 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)