### PR TITLE
Exclude appveyor.yml from Forge package builds

### DIFF
--- a/.pdkignore
+++ b/.pdkignore
@@ -41,3 +41,4 @@
 /.vscode/
 /.sync.yml
 /.devcontainer/
+/appveyor.yml


### PR DESCRIPTION
Adds `/appveyor.yml` to `.pdkignore` so the legacy AppVeyor CI config is excluded from `pdk build` artifacts uploaded to the Forge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)