### PR TITLE
Update project_page URL to main branch

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
   "summary": "To alleviate a thundering herd condition,tasks that will randomise the restart of the puppet agent based on the current runinterval",
   "license": "Apache-2.0",
   "source": "https://github.com/MartyEwings/thundering_herd_resolver.git",
-  "project_page": "https://github.com/MartyEwings/thundering_herd_resolver/blob/master/README.md",
+  "project_page": "https://github.com/MartyEwings/thundering_herd_resolver/blob/main/README.md",
   "issues_url": "https://github.com/MartyEwings/thundering_herd_resolver/issues",
   "dependencies": [
 


### PR DESCRIPTION
Follow-up to the `master` → `main` default-branch rename: updates the `project_page` URL in `metadata.json` from `/blob/master/` to `/blob/main/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)